### PR TITLE
Add system column support to the USING join clause

### DIFF
--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -1719,7 +1719,7 @@ buildVarFromNSColumn(ParseState *pstate, ParseNamespaceColumn *nscol)
  * buildVarFromSystemColumn -
  *	  build a Var node using "special" attribute, e.g. "xmin".
  * rtindex is the relation's index in the rangetable.
- * attnum is the relation's index in the rangetable.
+ * attnum is the number of "special" attribute.
  * Return NULL if there is no such system attribute.
  */
 static Var *

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -1361,21 +1361,16 @@ transformFromClauseItem(ParseState *pstate, Node *n,
 					sysatt = SystemAttributeByName(u_colname);
 
 					if (sysatt == NULL)
-					{
 						ereport(ERROR,
 							(errcode(ERRCODE_UNDEFINED_COLUMN),
 							 errmsg("column \"%s\" specified in USING clause does not exist in left table",
 									u_colname)));
-					}
-					else
-					{
-						/* System column,
-						 * so use predetermined type data to construct Var
-						 */
-						l_colvar = buildVarFromSystemColumn(pstate,
-															l_nsitem->p_rtindex,
-															sysatt->attnum);
-					}														
+					/* System column,
+						* so use predetermined type data to construct Var
+						*/
+					l_colvar = buildVarFromSystemColumn(pstate,
+														l_nsitem->p_rtindex,
+														sysatt->attnum);
 				}
 				else
 				{
@@ -1414,21 +1409,16 @@ transformFromClauseItem(ParseState *pstate, Node *n,
 					sysatt = SystemAttributeByName(u_colname);
 
 					if (sysatt == NULL)
-					{
 						ereport(ERROR,
 							(errcode(ERRCODE_UNDEFINED_COLUMN),
 							 errmsg("column \"%s\" specified in USING clause does not exist in right table",
 									u_colname)));
-					}
-					else
-					{
-						/* System column,
-						 * so use predetermined type data to construct Var
-						 */
-						r_colvar = buildVarFromSystemColumn(pstate,
-															r_nsitem->p_rtindex,
-															sysatt->attnum);
-					}														
+					/* System column,
+						* so use predetermined type data to construct Var
+						*/
+					r_colvar = buildVarFromSystemColumn(pstate,
+														r_nsitem->p_rtindex,
+														sysatt->attnum);
 				}
 				else
 				{
@@ -1730,23 +1720,19 @@ buildVarFromSystemColumn(ParseState *pstate, int rtindex, int attnum)
 
 	sysatt = SystemAttributeDefinition(attnum);
 
-	if (sysatt != NULL)
-	{
-		var = makeVar(rtindex,
-					attnum,
-					sysatt->atttypid,
-					sysatt->atttypmod,
-					sysatt->attcollation,
-					0);
+    if (sysatt == NULL)
+        return NULL;
 
-		/* update varnullingrels */
-		markNullableIfNeeded(pstate, var);
-		return var;
-	}
-	else
-	{
-		return NULL;
-	}	
+    var = makeVar(rtindex,
+                attnum,
+                sysatt->atttypid,
+                sysatt->atttypmod,
+                sysatt->attcollation,
+                0);
+
+    /* update varnullingrels */
+    markNullableIfNeeded(pstate, var);
+    return var;
 }
 
 /*


### PR DESCRIPTION
Parser can't handle using join over system columns. The problem with the USING
clause can be demonstrated with this code:
```sql
CREATE TABLE h (id int);
# CREATE TABLE

EXPLAIN (COSTS OFF) SELECT * FROM h JOIN h hh USING (xmin);
# ERROR:  column "xmin" specified in USING clause does not exist in left table

EXPLAIN (COSTS OFF) SELECT * FROM h JOIN h hh ON h.xmin = hh.xmin;
# QUERY PLAN.
# ...
```

**The Algorithm:**

1. If a column does not exist in the table, try to find it among the system
columns.
2. If a column with such a name exists among the system columns, construct
a `Var`. Construct the `Var` similarly as shown here: [Parse Relation](https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/backend/parser/parse_relation.c;h=2f64eaf0e371a82220f54ba97e5d1e81faf61947;hb=refs/heads/master#l757).
3. During processing, do not collect the system column's name in the `colnos`
list, similar to how the `JOIN ON ... = ...` clause works with system columns.

**Testing:**

The correctness was tested only manually with SQL commands:
```sql
-- Create the table
CREATE TABLE h  (id int);
CREATE TABLE hh (id int);

-- Insert some data: first transaction
BEGIN;
INSERT INTO h  (id) VALUES (1);
INSERT INTO hh (id) VALUES (101);
COMMIT;

-- Insert some data: second transaction
BEGIN;
INSERT INTO h  (id) VALUES (2);
INSERT INTO hh (id) VALUES (102);
COMMIT;

-- Check the xmin values
SELECT id, xmin FROM h;
SELECT id, xmin FROM hh;

-- Join the tables using xmin
SELECT * FROM h JOIN hh USING (xmin);
-- Should return:
-- id | id  
-- ---+-----
--  1 | 101
--  2 | 102
-- (2 rows)

-- These commands should produce equal results:
EXPLAIN (COSTS OFF) SELECT * FROM h JOIN hh USING (xmin);
EXPLAIN (COSTS OFF) SELECT * FROM h JOIN hh ON h.xmin = hh.xmin;
```
Needs unit testing and integration testing.

**To make, install, and execute PostgreSQL, I've used these commands (see instructions 
[PostgreSQL Install](https://www.postgresql.org/docs/devel/install-make.html#INSTALL-SHORT-MAKE)):**
```bash
# Make and install
./configure --prefix=$HOME/gpdata/pgsql_bin CFLAGS="-O0 -g3"
make -s -j`nproc`
make -s install
mkdir -p $HOME/gpdata/data_pgsql

# Executing
$HOME/gpdata/pgsql_bin/bin/initdb -D $HOME/gpdata/data_pgsql
$HOME/gpdata/pgsql_bin/bin/pg_ctl -D $HOME/gpdata/data_pgsql -l logfile start
export PATH=$HOME/gpdata/pgsql_bin/bin:$PATH
export LD_LIBRARY_PATH=$HOME/gpdata/pgsql_bin/lib:$LD_LIBRARY_PATH
$HOME/gpdata/pgsql_bin/bin/createdb test
$HOME/gpdata/pgsql_bin/bin/psql test

# To stop the server
$HOME/gpdata/pgsql_bin/bin/pg_ctl -D $HOME/gpdata/data_pgsql stop
```