### PR TITLE
Add system column support to the USING clause

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -264,6 +264,14 @@ SystemAttributeByName(const char *attname)
 	return NULL;
 }
 
+/*
+ * Returns the total number of system attributes.
+ */
+size_t SystemAttributeTotalNumber(void)
+{
+	return lengthof(SysAtt);
+}
+
 
 /* ----------------------------------------------------------------
  *				XXX END OF UGLY HARD CODED BADNESS XXX

--- a/src/include/catalog/heap.h
+++ b/src/include/catalog/heap.h
@@ -136,6 +136,8 @@ extern const FormData_pg_attribute *SystemAttributeDefinition(AttrNumber attno);
 
 extern const FormData_pg_attribute *SystemAttributeByName(const char *attname);
 
+extern size_t SystemAttributeTotalNumber(void);
+
 extern void CheckAttributeNamesTypes(TupleDesc tupdesc, char relkind,
 									 int flags);
 

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -8017,3 +8017,109 @@ SELECT t1.a FROM skip_fetch t1 LEFT JOIN skip_fetch t2 ON t2.a = 1 WHERE t2.a IS
 
 RESET enable_indexonlyscan;
 RESET enable_seqscan;
+-- Test USING with system columns
+-- Generate 2 tables with 3 rows each.
+-- xmin (transaction number) is an integer value represented as T1, T2, etc.
+-- The xmin values of the first and second rows are equal to each other,
+-- respectively. The values T3 and T4 of the third rows are not equal.
+-- J1: id1 | xmin      J2: id2 | xmin
+--     ----+-------       -----+-------
+--       1 | T1            101 | T1
+--       2 | T2            102 | T2
+--       3 | T3            103 | T4
+CREATE TABLE j1 (id1 INT);
+CREATE TABLE j2 (id2 INT);
+BEGIN;
+  INSERT INTO j1 (id1) VALUES (1);
+  INSERT INTO j2 (id2) VALUES (101);
+COMMIT;
+BEGIN;
+  INSERT INTO j1 (id1) VALUES (2);
+  INSERT INTO j2 (id2) VALUES (102);
+COMMIT;
+BEGIN;
+  INSERT INTO j1 (id1) VALUES (3);
+COMMIT;
+BEGIN;
+  INSERT INTO j2 (id2) VALUES (103);
+COMMIT;
+-- The xmin values are not output, as they will differ with each run.
+-- So, only the column headers and the values of id1 and id2 are displayed.
+SELECT * FROM j1 JOIN j2 USING (xmin) LIMIT 0;
+ xmin | id1 | id2 
+------+-----+-----
+(0 rows)
+
+SELECT j1.id1, j2.id2 FROM j1 JOIN j2 USING (xmin);
+ id1 | id2 
+-----+-----
+   1 | 101
+   2 | 102
+(2 rows)
+
+SELECT * FROM j1 LEFT JOIN j2 USING (xmin) LIMIT 0;
+ xmin | id1 | id2 
+------+-----+-----
+(0 rows)
+
+SELECT j1.id1, j2.id2 FROM j1 LEFT JOIN j2 USING (xmin);
+ id1 | id2 
+-----+-----
+   1 | 101
+   2 | 102
+   3 |    
+(3 rows)
+
+SELECT * FROM j1 RIGHT JOIN j2 USING (xmin) LIMIT 0;
+ xmin | id1 | id2 
+------+-----+-----
+(0 rows)
+
+SELECT j1.id1, j2.id2 FROM j1 RIGHT JOIN j2 USING (xmin);
+ id1 | id2 
+-----+-----
+   1 | 101
+   2 | 102
+     | 103
+(3 rows)
+
+SELECT * FROM j1 FULL JOIN j2 USING (xmin) LIMIT 0;
+ xmin | id1 | id2 
+------+-----+-----
+(0 rows)
+
+SELECT j1.id1, j2.id2 FROM j1 FULL JOIN j2 USING (xmin);
+ id1 | id2 
+-----+-----
+   1 | 101
+   2 | 102
+   3 |    
+     | 103
+(4 rows)
+
+-- Test if USING can add all system columns at once
+SELECT *
+  FROM j1 JOIN j2 USING (tableoid, xmin, cmin, xmax, cmax, ctid);
+ tableoid | xmin | cmin | xmax | cmax | ctid | id1 | id2 
+----------+------+------+------+------+------+-----+-----
+(0 rows)
+
+-- Test USING exceptions
+SELECT * FROM j1 JOIN j2 USING (id2);
+ERROR:  column "id2" specified in USING clause does not exist in left table
+SELECT * FROM j1 JOIN j2 USING (id1);
+ERROR:  column "id1" specified in USING clause does not exist in right table
+WITH j1_dubbed AS (SELECT id1, id1 FROM j1)
+  SELECT * FROM j1_dubbed JOIN j1 USING (id1);
+ERROR:  common column name "id1" appears more than once in left table
+WITH j1_dubbed AS (SELECT id1, id1 FROM j1)
+  SELECT * FROM j1 JOIN j1_dubbed USING (id1);
+ERROR:  common column name "id1" appears more than once in right table
+-- Test multiple USING joins, each based on the prior result.
+CREATE TABLE j3 (id3 INT);
+SELECT * FROM j1 JOIN j2 USING (xmin) JOIN j3 USING (xmin) LIMIT 0;
+ xmin | id1 | id2 | id3 
+------+-----+-----+-----
+(0 rows)
+
+DROP TABLE j1, J2, J3;


### PR DESCRIPTION
Add system column support to the USING clause

Problem: The parser can't handle USING joins with system columns, such as xmin.

Solution:
1. Use the scanNSItemForColumn() function instead of buildVarFromNSColumn() for
constructing Var objects, as it correctly handles system columns.
2. Remove extra calls to markVarForSelectPriv(), since this function is already
invoked in scanNSItemForColumn().
3. For system columns, collect their negative attribute numbers along with
user-defined column indices into l_colnos and r_colnos.
4. Create a buildVarFromSystemAttribute() function for rebuilding Var objects
with system attributes, analogous to buildVarFromNSColumn(), since
scanNSItemForColumn() is complex and has side effects.
5. Implement a fillNSColumnParametersFromVar() function for building NS columns
with system attributes.
6. Add SystemAttributeTotalNumber() function to heap.c to ensure memory for
res_nscolumns is allocated with system columns in mind.

